### PR TITLE
Fix for Shopify redirect url id

### DIFF
--- a/lib/AuthRedirect.js
+++ b/lib/AuthRedirect.js
@@ -16,7 +16,10 @@ var installWebAppHandler = _.once(function() {
         var code = uri.query.code;
         var signature = uri.query.signature;
         var timestamp = uri.query.timestamp;
-        var uuid = uri.query.id;
+
+        // The state parameter should be our original redirect id
+        // If not, we should not continue, since something has gone wrong
+        var uuid = uri.query.state;
 
         var handler = handlers[uuid];
         if (!handler) {
@@ -76,9 +79,8 @@ Shopify._getPermanentAccessToken = function(authenticatorConfig, code, callback)
 var asyncHandleAuthRedirect = function(authenticatorConfig, callback) {
     var redirect_uri = authenticatorConfig.redirect_uri;
 
-    var uri = url.parse(redirect_uri, true);
-    var path = uri.path;
-    var uuid = path.replace("/__shopify-auth?id=", "");
+    // Pick out the redirect id associated with this request
+    var uuid = authenticatorConfig.redirect_id;
 
     handlers[uuid] = {
         authenticatorConfig: authenticatorConfig,

--- a/lib/Authenticators.js
+++ b/lib/Authenticators.js
@@ -167,13 +167,19 @@ Shopify.PublicAppOAuthAuthenticator = function PublicAppOAuthAuthenticator(optio
     this.config.post_auth_uri = options.post_auth_uri || "close";
     this.config.onAuth = options.onAuth || function() { };
 
+    // Create a unique id for the authentication, which will be passed back to
+    // our handler from Shopify so we can find the original authentication request
+    this.config.redirect_id = options.redirect_id || Meteor.uuid();
+
+
     // Shopify will redirect to this address after login.
     if (options.redirect_uri) {
         // Library consumer will handle code -> access_token upgrade.
         this.config.redirect_uri = options.redirect_uri;
     } else {
         // Automatic handling.
-        this.config.redirect_uri = Meteor.absoluteUrl("__shopify-auth?id=" + Meteor.uuid());
+
+        this.config.redirect_uri = Meteor.absoluteUrl("__shopify-auth");
 
         // Install handler for automatic handling.  The library conusmer still
         // has to somehow navigate to auth_uri, be it in a new tab, an iframe,
@@ -198,7 +204,10 @@ Shopify.PublicAppOAuthAuthenticator = function PublicAppOAuthAuthenticator(optio
         "&scope=",
         this.config.scopes,
         "&redirect_uri=",
-        encodeURIComponent(this.config.redirect_uri)
+        encodeURIComponent(this.config.redirect_uri),
+        // Add the unique id as a 'state' parameter in the auth uri
+        "&state=",
+        this.config.redirect_id
     ].join("");
 
     this.ready = false;


### PR DESCRIPTION
Replaced id parameter on redirect uri with a new 'redirect id' appended as the 'state' parameter on the auth uri.
